### PR TITLE
Add new external etcd reference architecture

### DIFF
--- a/.env
+++ b/.env
@@ -12,10 +12,18 @@ WORKSHOP_VERSION=0.2.0
 COMPOSE_PROJECT_NAME=workshop
 COMPOSE_FILE=docker-compose-default.yaml
 
+## Etcd =======================================================================
+ETCD_VERSION=v3.3.22
+ETCD_HOST=workshop_etcd_1
+
+## Nginx (Sensu LB) ===========================================================
+NGINX_VERSION=1.19.2
+
 ## Sensu Go (Backend) =========================================================
-SENSU_BACKEND_VERSION=5.21.0
+SENSU_BACKEND_VERSION=5.21.2
 SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=sensu
 SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=sensu
+SENSU_ETCD_CLIENT_URLS=http://workshop_etcd_1:2379
 
 ## Sensu Go (Secrets) =========================================================
 SENSU_TIMESCALEDB_DSN=postgresql://postgres:sensu@timescaledb:5432/sensu
@@ -26,13 +34,13 @@ INFLUXDB_PASSWORD=password
 # PAGERDUTY_TOKEN=xxxxxxxxxxxxxxxxxxxx
 
 ## Sensu Go (Agent) ===========================================================
-SENSU_AGENT_VERSION=5.21.0
+SENSU_AGENT_VERSION=5.21.2
 SENSU_BACKEND_URL=ws://sensu-backend:8081
 SENSU_SUBSCRIPTIONS=linux,workshop,devel
 SENSU_NAMESPACE=default
 
 ## Sensu Go (CLI) =============================================================
-SENSU_CLI_VERSION=5.21.0
+SENSU_CLI_VERSION=5.21.2
 SENSU_API_URL=http://sensu-backend:8080
 SENSU_USERNAME=sensu
 SENSU_PASSWORD=sensu

--- a/.env
+++ b/.env
@@ -20,7 +20,7 @@ ETCD_HOST=workshop_etcd_1
 NGINX_VERSION=1.19.2
 
 ## Sensu Go (Backend) =========================================================
-SENSU_BACKEND_VERSION=5.21.2
+SENSU_BACKEND_VERSION=6.0.0
 SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=sensu
 SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=sensu
 SENSU_ETCD_CLIENT_URLS=http://workshop_etcd_1:2379
@@ -34,13 +34,13 @@ INFLUXDB_PASSWORD=password
 # PAGERDUTY_TOKEN=xxxxxxxxxxxxxxxxxxxx
 
 ## Sensu Go (Agent) ===========================================================
-SENSU_AGENT_VERSION=5.21.2
+SENSU_AGENT_VERSION=6.0.0
 SENSU_BACKEND_URL=ws://sensu-backend:8081
 SENSU_SUBSCRIPTIONS=linux,workshop,devel
 SENSU_NAMESPACE=default
 
 ## Sensu Go (CLI) =============================================================
-SENSU_CLI_VERSION=5.21.2
+SENSU_CLI_VERSION=6.0.0
 SENSU_API_URL=http://sensu-backend:8080
 SENSU_USERNAME=sensu
 SENSU_PASSWORD=sensu

--- a/config/nginx/nginx.asset.conf
+++ b/config/nginx/nginx.asset.conf
@@ -1,0 +1,22 @@
+events {
+    worker_connections  1024;
+}
+
+http {
+    server {
+        listen 80;
+        root /usr/share/nginx/html;
+
+        location / {
+            autoindex   on;
+            sendfile    on;
+            sendfile_max_chunk  1m;
+        }
+
+        location /assets/ {
+            autoindex   on;
+            sendfile    on;
+            sendfile_max_chunk  1m;
+        }
+    }
+}

--- a/config/nginx/nginx.default.conf
+++ b/config/nginx/nginx.default.conf
@@ -4,15 +4,10 @@ events {
 
 http {
     server {
+        listen 80;
         root /usr/share/nginx/html;
 
         location / {
-            autoindex   on;
-            sendfile    on;
-            sendfile_max_chunk  1m;
-        }
-
-        location /assets/ {
             autoindex   on;
             sendfile    on;
             sendfile_max_chunk  1m;

--- a/config/nginx/nginx.lb.conf
+++ b/config/nginx/nginx.lb.conf
@@ -1,0 +1,61 @@
+events {
+    worker_connections  1024;
+}
+
+http {
+    upstream sensu-backend-etcd {
+        ip_hash;
+        include /etc/nginx/upstream_etcd.conf;
+    }
+
+    server {
+        listen 2379;
+
+        location / {
+            proxy_set_header Host $host;
+            proxy_pass http://sensu-backend-etcd;
+        }
+    }
+
+    upstream sensu-backend-app {
+        ip_hash;
+        include /etc/nginx/upstream_app.conf;
+    }
+
+    server {
+        listen 3000;
+
+        location / {
+            proxy_set_header Host $host;
+            proxy_pass http://sensu-backend-app;
+        }
+    }
+
+    upstream sensu-backend-api {
+        least_conn;
+        include /etc/nginx/upstream_api.conf;
+    }
+
+    server {
+        listen 8080;
+
+        location / {
+            proxy_set_header Host $host;
+            proxy_pass http://sensu-backend-api;
+        }
+    }
+
+    upstream sensu-backend-websockets {
+        ip_hash;
+        include /etc/nginx/upstream_websockets.conf;
+    }
+
+    server {
+        listen 8081;
+
+        location / {
+            proxy_set_header Host $host;
+            proxy_pass http://sensu-backend-websockets;
+        }
+    }
+}

--- a/config/nginx/upstream_api.conf
+++ b/config/nginx/upstream_api.conf
@@ -1,0 +1,1 @@
+server workshop_sensu-backend_1:8080;

--- a/config/nginx/upstream_app.conf
+++ b/config/nginx/upstream_app.conf
@@ -1,0 +1,1 @@
+server workshop_sensu-backend_1:3000;

--- a/config/nginx/upstream_etcd.conf
+++ b/config/nginx/upstream_etcd.conf
@@ -1,0 +1,1 @@
+server workshop_etcd_1:2379;

--- a/config/nginx/upstream_websockets.conf
+++ b/config/nginx/upstream_websockets.conf
@@ -1,0 +1,1 @@
+server workshop_sensu-backend_1:8081;

--- a/docker-compose-external-etcd.yaml
+++ b/docker-compose-external-etcd.yaml
@@ -1,7 +1,41 @@
 ---
 version: "3.3"
 services:
-  # Sensu Backend 
+  # Etcd
+  #
+  # Standalone etcd server.  
+  # 
+  # See: https://etcd.io/docs/v3.4.0/op-guide/container/#running-a-single-node-etcd-1
+  etcd:
+    image: gcr.io/etcd-development/etcd:${ETCD_VERSION}
+    labels:
+    - io.sensu.role=sensu-backend-etcd
+    healthcheck:
+      test: wget -q -O- http://127.0.0.1:2379/health
+      interval: 10s
+      timeout: 5s
+      retries: 6
+    ports:
+    - 2379:2379
+    - 2380:2380
+    environment:
+    - ETCD_HOST
+    volumes:
+    - type: volume 
+      source: etcd_data
+      target: /var/lib/etcd
+    command: >-
+      /usr/local/bin/etcd 
+      --data-dir=/var/lib/etcd
+      --name etcd-1 
+      --initial-cluster-state "new"
+      --initial-advertise-peer-urls "http://${ETCD_HOST}:2380" 
+      --listen-peer-urls "http://0.0.0.0:2380" 
+      --advertise-client-urls "http://${ETCD_HOST}:2379" 
+      --listen-client-urls "http://0.0.0.0:2379" 
+      --initial-cluster "etcd-1=http://${ETCD_HOST}:2380"
+
+  # Sensu Backend Cluster
   #
   # Includes embedded database, API, event processor, and web UI). 
   # 
@@ -9,22 +43,21 @@ services:
   sensu-backend:
     # container_name: sensu-backend
     image: sensu/sensu:${SENSU_BACKEND_VERSION}
+    depends_on: 
+    - etcd
     labels:
     - io.sensu.role=sensu-backend
-    ports:
-    - 3000:3000
-    - 8080:8080
-    - 8081:8081
     healthcheck:
       test: wget -q -O- http://127.0.0.1:8080/health
       interval: 10s
       timeout: 5s
       retries: 6
     environment:
-    - SENSU_BACKEND_CLUSTER_ADMIN_USERNAME
-    - SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD
     - SENSU_TIMESCALEDB_DSN
     - PAGERDUTY_TOKEN
+    - SENSU_NO_EMBED_ETCD=true
+    - SENSU_ETCD_CLIENT_URLS=http://workshop_etcd_1:2379
+    - ETCD_CLIENT_URLS=${SENSU_ETCD_CLIENT_URLS}
     volumes:
     - type: volume 
       source: sensu_data
@@ -33,6 +66,8 @@ services:
       sensu-backend start 
       --log-level=debug
       --debug=true
+      --no-embed-etcd
+      --etcd-client-urls ${SENSU_ETCD_CLIENT_URLS}
 
   # Sensu Agent 
   #
@@ -42,6 +77,8 @@ services:
   sensu-agent:
     # container_name: sensu-agent
     image: sensu/sensu:${SENSU_AGENT_VERSION}
+    depends_on:
+    - sensu-backend
     labels:
     - io.sensu.role=sensu-agent
     healthcheck:
@@ -62,6 +99,44 @@ services:
       --deregister=true 
       --detect-cloud-provider
       --labels="environment=training,workshop_version=${WORKSHOP_VERSION}"
+
+  # Sensu Backend Load Balancer
+  # 
+  # Nginx load balancer
+  # 
+  # See: https://nginx.com 
+  sensu-lb:
+    container_name: sensu-backend
+    image: nginx:${NGINX_VERSION}
+    depends_on:
+    - sensu-backend
+    labels:
+    - io.sensu.role=sensu-lb
+    ports:
+    - 3000:3000
+    - 8080:8080
+    - 8081:8081
+    healthcheck:
+      test: curl --fail http://127.0.0.1:8080/health
+      interval: 10s
+      timeout: 5s
+      retries: 6
+    volumes:
+    - type: bind
+      source: ./config/nginx/nginx.lb.conf
+      target: /etc/nginx/nginx.conf
+    - type: bind 
+      source: ./config/nginx/upstream_app.conf
+      target: /etc/nginx/upstream_etcd.conf
+    - type: bind 
+      source: ./config/nginx/upstream_app.conf
+      target: /etc/nginx/upstream_app.conf
+    - type: bind 
+      source: ./config/nginx/upstream_api.conf
+      target: /etc/nginx/upstream_api.conf
+    - type: bind 
+      source: ./config/nginx/upstream_websockets.conf
+      target: /etc/nginx/upstream_websockets.conf
 
   # TimescaleDB  
   #
@@ -140,12 +215,13 @@ services:
       - SENSU_CLI_VERSION
     image: workshop:${SENSU_CLI_VERSION}
     depends_on:
-    - sensu-backend
+    - etcd
     labels:
     - io.sensu.role=configurator
     environment:
     - SENSU_BACKEND_CLUSTER_ADMIN_USERNAME
     - SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD
+    - SENSU_ETCD_CLIENT_URLS
     volumes:
     - type: bind
       source: /var/run/docker.sock
@@ -223,6 +299,8 @@ services:
       --format tabular
       
 volumes:
+  etcd_data:
+    driver: local
   sensuctl_data:
     driver: local
   sensu_data:

--- a/docker/workshop/Dockerfile
+++ b/docker/workshop/Dockerfile
@@ -7,6 +7,7 @@ RUN sensuctl version
 # Build the workshop workstation image
 FROM alpine:latest 
 COPY --from=sensu /usr/local/bin/sensuctl /usr/local/bin/
+COPY --from=sensu /opt/sensu/bin/sensu-backend /usr/local/bin/
 ENV PATH=$PATH:/usr/local/bin/scripts
 RUN apk add curl jq gettext docker-cli docker-compose
 

--- a/scripts/generate_user_rbac
+++ b/scripts/generate_user_rbac
@@ -25,6 +25,22 @@ USERS_JSON=${1:-"users/users.json"}
 USER_TEMPLATE=${2:-"users/user.yaml.template"}
 OUTPUT_DIRECTORY=${3:-"config/sensu/rbac"}
 OUTPUT_FORMAT=${4:-"yaml"}
+SENSU_ETCD_CLIENT_URLS=${SENSU_ETCD_CLIENT_URLS}
+SENSU_INIT_TEMP_FILE="/root/.config/init"
+
+sensu_backend_init() {
+  if [ ! -f ${SENSU_INIT_TEMP_FILE} ]; then
+    if [ ! -z ${SENSU_ETCD_CLIENT_URLS} ]; then
+      sensu-backend init --etcd-client-urls ${SENSU_ETCD_CLIENT_URLS}
+      if [ $? -eq 0 ]; then
+        touch ${SENSU_INIT_TEMP_FILE}
+        exit 0
+      fi
+      exit 1
+    fi
+  fi
+  exit 0
+}
 
 check_deps() {
   for DEP in jq base64 envsubst
@@ -82,3 +98,4 @@ check_deps
 validate_io
 validate_json
 create_users
+sensu_backend_init

--- a/scripts/wait-for-sensu-backend
+++ b/scripts/wait-for-sensu-backend
@@ -1,9 +1,10 @@
 #!/usr/bin/env sh
 
-export SENSU_API_URL=${SENSU_API_URL:-"http://127.0.0.1:8080"}
-export SENSU_USERNAME=${SENSU_USERNAME}
-export SENSU_PASSWORD=${SENSU_PASSWORD}
-export SENSU_NAMESPACE=${SENSU_NAMESPACE:-default}
+SENSU_API_URL=${SENSU_API_URL:-"http://127.0.0.1:8080"}
+SENSU_USERNAME=${SENSU_USERNAME}
+SENSU_PASSWORD=${SENSU_PASSWORD}
+SENSU_NAMESPACE=${SENSU_NAMESPACE:-default}
+SENSU_INIT_TEMP_FILE="/root/.config/init"
 INTERVAL=2
 RETRIES=5
 ATTEMPT=0
@@ -28,6 +29,7 @@ fi
 if [ $ATTEMPT -gt 0 -a $SUCCESS -gt 0 ]; then
   # only display success message if we don't connect on the first try
   echo "Successfully connected to ${SENSU_API_URL}"  
+  touch ${SENSU_INIT_TEMP_FILE}
 fi 
 
 exec $@


### PR DESCRIPTION
Includes: 

- External etcd 
- Easily scale the sensu-backend (i.e. `docker-compose up -d --scale sensu-backend=3`) 
- Includes a load balancer (Nginx) for the web UI, API, and websockets 
- Moved `sensu-backend init` to the configurator (see: https://github.com/sensu/sensu-docker/issues/1)