### PR TITLE
Don't index the /config directory containing user .envrc files

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -20,7 +20,14 @@ http {
             sendfile    on;
             sendfile_max_chunk  1m;
         }
-        
+
+        # Asset File Server
+        location /config/ {
+            autoindex   off;
+            sendfile    on;
+            sendfile_max_chunk  1m;
+        }
+
         # NGINX Status Module
         location /nginx_status {
             stub_status;


### PR DESCRIPTION
Just a little security by obscurity... 