### PR TITLE
add rocket chat as containerized shared chat instance to replace slack 

### DIFF
--- a/.env
+++ b/.env
@@ -76,6 +76,10 @@ ES_URL=http://elasticsearch:9200
 ES_USERNAME=sensu
 ES_PASSWORD=sensu
 
+## Rocketchat =================================================================
+ROCKETCHAT_ADMIN_USER="admin"
+ROCKETCHAT_ADMIN_PASSWORD="admin"
+
 ## Hashicorp Vault ============================================================
 VAULT_VERSION=1.6.3
 VAULT_DEV_ROOT_TOKEN_ID=secretsmanager

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ config/sensu/rbac/*
 
 # ignore workshop artifacts
 slack.yaml
+rocketchat.yaml
 influxdb.yaml
 filter-repeated.yaml
 disk.yaml

--- a/SETUP.md
+++ b/SETUP.md
@@ -221,7 +221,9 @@
    This workshop environment includes a Hashicorp Vault server running in ["dev server mode"](https://www.vaultproject.io/docs/concepts/dev-server).
    To configure Vault secrets that trainees will need access to during the workshop (e.g. Pagerduty API Token and Slack Webhook URL), please modify the files in `/config/vault/secrets`.
    Additional secrets may be added to Vault by adding JSON files in `/config/vault/secrets`, but corresponding Sensu Secrets will need to be configured in order to make these secrets available in Sensu.
-
+   
+   Note: Secrets for workshop containerized services, such as RocketChat will be seeded automatically.  
+ 
 1. **Docker Compose initialization.**
 
    ```shell

--- a/config/sensu/seeds/rocketchat.yaml
+++ b/config/sensu/seeds/rocketchat.yaml
@@ -67,46 +67,45 @@ spec:
     - entity.system.os == 'windows'
     - entity.system.arch == 'amd64'
     headers: null
-    sha512: 3d4cba800075b1adb2326ad0bdce8fcd33ecde707e46a535a9090f639e5a1285aba099999439ac740402f1ac9094d1d88b4e1bb74c0ac7b9245b1788c7acc038
-    url: https://assets.bonsai.sensu.io/a2299af95a4fa0aed9da508f70262eab4b971b52/sensu-rocketchat-handler_0.1.0_windows_amd64.tar.gz
+    sha512: a152e412a4612fff736102ac321e1abc7a2d0de8be1c92143d7f7c515f78c47210e0aa548f7395e3dac41366f2de4d33a876351240a9a74782976fe47b26b8c5
+    url: https://assets.bonsai.sensu.io/84d89696e51ce8e3fb7a580721423570afbdd908/sensu-rocketchat-handler_0.1.0_windows_amd64.tar.gz
   - filters:
     - entity.system.os == 'darwin'
     - entity.system.arch == 'amd64'
     headers: null
-    sha512: 5ee04dae0e05ac6746de06f5966b28057c011395bdc930b46ae60e1d8168cfb6ef193ace1fd17563f6008cdb320c8aa4f0b59aac820d76cbe24e39aff3140d69
-    url: https://assets.bonsai.sensu.io/a2299af95a4fa0aed9da508f70262eab4b971b52/sensu-rocketchat-handler_0.1.0_darwin_amd64.tar.gz
+    sha512: 05063d0dd466da0e4adcbb09255f9ce89f5d9338917577bf1aac68c59d084400d4acdfbe8176fb6a6a2fc173de09b6be075dff16d86b9de9422b666850087012
+    url: https://assets.bonsai.sensu.io/84d89696e51ce8e3fb7a580721423570afbdd908/sensu-rocketchat-handler_0.1.0_darwin_amd64.tar.gz
   - filters:
     - entity.system.os == 'linux'
     - entity.system.arch == 'arm'
     - entity.system.arm_version == 6
     headers: null
-    sha512: b7800ab1b15e92b35a8154fdd4cfca57086c05f4ce479fd40e2cc6787fbe257645cb889e36863c893a8346edf3afcc4bf6fda6d28d48b01e29b163c990b02c9c
-    url: https://assets.bonsai.sensu.io/a2299af95a4fa0aed9da508f70262eab4b971b52/sensu-rocketchat-handler_0.1.0_linux_armv6.tar.gz
+    sha512: fd576a80159e6f68e93256a9d02eb87658ae01f30e0df71c96ae342bc4eb79b0b389d29ce1bbbad87d12fd99e38150a14a302a5ef46860c2ecadd49543f7adc6
+    url: https://assets.bonsai.sensu.io/84d89696e51ce8e3fb7a580721423570afbdd908/sensu-rocketchat-handler_0.1.0_linux_armv6.tar.gz
   - filters:
     - entity.system.os == 'linux'
     - entity.system.arch == 'arm'
     - entity.system.arm_version == 7
     headers: null
-    sha512: 695c82e4be6a2be6623027a5ef8189b36a615353c0411e5038b6d066e50373811d79172a8c2c71f9fbdcc6975a37aa21b3e77bf63cc3ba163209f9985de7534b
-    url: https://assets.bonsai.sensu.io/a2299af95a4fa0aed9da508f70262eab4b971b52/sensu-rocketchat-handler_0.1.0_linux_armv7.tar.gz
+    sha512: 4f253c0805d48862294dbbee3f398ebb2c4583f3126d2e199b55569e8f41db867631ad4e3bddb590859828a4f3aaa6827283931439b5b59b6e59abe77eceace6
+    url: https://assets.bonsai.sensu.io/84d89696e51ce8e3fb7a580721423570afbdd908/sensu-rocketchat-handler_0.1.0_linux_armv7.tar.gz
   - filters:
     - entity.system.os == 'linux'
     - entity.system.arch == 'arm64'
     headers: null
-    sha512: fba3f70db5925d59c2664777b88d5f1623ebfd12479406c133d9f5f4323e82b6ed998e751abe14579388412cdaffec981f21a8e2d0fc28e45b74d1010103e9b2
-    url: https://assets.bonsai.sensu.io/a2299af95a4fa0aed9da508f70262eab4b971b52/sensu-rocketchat-handler_0.1.0_linux_arm64.tar.gz
+    sha512: 492d628a5a1ad3d2d1fcf569c609d32e6dff8d91946afd287690cac25b79022e7f0d101c0de6a832bffaf58f666657ed9702279acf672fbee85d81cc676f3d2a
+    url: https://assets.bonsai.sensu.io/84d89696e51ce8e3fb7a580721423570afbdd908/sensu-rocketchat-handler_0.1.0_linux_arm64.tar.gz
   - filters:
     - entity.system.os == 'linux'
     - entity.system.arch == '386'
     headers: null
-    sha512: ee658b9e362ad3ef3b14e0b3cb889d823b10f390345cc01e02b7b1fb9c4adb321dedc878d3e542d081c16841babb7b3ea1067c53486de5928755b118b0dc12b1
-    url: https://assets.bonsai.sensu.io/a2299af95a4fa0aed9da508f70262eab4b971b52/sensu-rocketchat-handler_0.1.0_linux_386.tar.gz
+    sha512: a2a85376ac9e7e01e23ef4109a45e27b6b865ef452eeb82cf532550b9afa299940a45ef51ccf16072f84dffe11c5c661c750b634d8a8a194253c1ffa99dfca2a
+    url: https://assets.bonsai.sensu.io/84d89696e51ce8e3fb7a580721423570afbdd908/sensu-rocketchat-handler_0.1.0_linux_386.tar.gz
   - filters:
     - entity.system.os == 'linux'
     - entity.system.arch == 'amd64'
     headers: null
-    sha512: 9e4337ca406e5aebf164cc6813ef58c2067db012aab8ee17d58f9bd1d464ae566942ce773513872e6fec6b08bc953fcbf72fcae29d45448985c96513d2665f53
-    url: https://assets.bonsai.sensu.io/a2299af95a4fa0aed9da508f70262eab4b971b52/sensu-rocketchat-handler_0.1.0_linux_amd64.tar.gz
+    sha512: bbe2817c57b8930895b5de479de2466a5aa9f3ee3c131b7a6c373510115dd38c118fe060294c583f92e326082cfa80bd07ed52eb7a116cc9225a3f3c529078d2
+    url: https://assets.bonsai.sensu.io/84d89696e51ce8e3fb7a580721423570afbdd908/sensu-rocketchat-handler_0.1.0_linux_amd64.tar.gz
   filters: null
   headers: null
-

--- a/config/sensu/seeds/rocketchat.yaml
+++ b/config/sensu/seeds/rocketchat.yaml
@@ -14,21 +14,4 @@ metadata:
 spec:
   provider: vault
   id: secret/sensu/rocketchat#id
----
-type: Asset
-api_version: core/v2
-metadata:
-  annotations:
-    io.sensu.bonsai.api_url: https://bonsai.sensu.io/api/v1/assets/sensu/sensu-rocketchat-handler
-    io.sensu.bonsai.name: sensu-rocketchat-handler
-    io.sensu.bonsai.namespace: sensu
-    io.sensu.bonsai.tags: ""
-    io.sensu.bonsai.tier: Supported
-    io.sensu.bonsai.url: https://bonsai.sensu.io/assets/sensu/sensu-rocketchat-handler
-    io.sensu.bonsai.version: 0.1.0
-  created_by: sensu
-  labels:
-    sensu.io/managed_by: sensuctl
-  name: sensu/sensu-rocketchat-handler:0.1.0
-spec:
-  builds:
+

--- a/config/sensu/seeds/rocketchat.yaml
+++ b/config/sensu/seeds/rocketchat.yaml
@@ -1,0 +1,34 @@
+---
+type: Secret
+api_version: secrets/v1
+metadata:
+  name: rocketchat_token
+spec:
+  provider: vault
+  id: secret/sensu/rocketchat#token
+---
+type: Secret
+api_version: secrets/v1
+metadata:
+  name: rocketchat_userid
+spec:
+  provider: vault
+  id: secret/sensu/rocketchat#id
+---
+type: Asset
+api_version: core/v2
+metadata:
+  annotations:
+    io.sensu.bonsai.api_url: https://bonsai.sensu.io/api/v1/assets/sensu/sensu-rocketchat-handler
+    io.sensu.bonsai.name: sensu-rocketchat-handler
+    io.sensu.bonsai.namespace: sensu
+    io.sensu.bonsai.tags: ""
+    io.sensu.bonsai.tier: Supported
+    io.sensu.bonsai.url: https://bonsai.sensu.io/assets/sensu/sensu-rocketchat-handler
+    io.sensu.bonsai.version: 0.1.0
+  created_by: sensu
+  labels:
+    sensu.io/managed_by: sensuctl
+  name: sensu/sensu-rocketchat-handler:0.1.0
+spec:
+  builds:

--- a/config/sensu/seeds/rocketchat.yaml
+++ b/config/sensu/seeds/rocketchat.yaml
@@ -46,4 +46,67 @@ metadata:
 spec:
   provider: vault
   id: secret/sensu/rocketchat#channel
+---
+type: Asset
+api_version: core/v2
+metadata:
+  annotations:
+    io.sensu.bonsai.api_url: https://bonsai.sensu.io/api/v1/assets/sensu/sensu-rocketchat-handler
+    io.sensu.bonsai.name: sensu-rocketchat-handler
+    io.sensu.bonsai.namespace: sensu
+    io.sensu.bonsai.tags: ""
+    io.sensu.bonsai.tier: Community
+    io.sensu.bonsai.url: https://bonsai.sensu.io/assets/sensu/sensu-rocketchat-handler
+    io.sensu.bonsai.version: 0.1.0
+  created_by: sensu
+  name: sensu/sensu-rocketchat-handler:0.1.0
+  namespace: default
+spec:
+  builds:
+  - filters:
+    - entity.system.os == 'windows'
+    - entity.system.arch == 'amd64'
+    headers: null
+    sha512: 3d4cba800075b1adb2326ad0bdce8fcd33ecde707e46a535a9090f639e5a1285aba099999439ac740402f1ac9094d1d88b4e1bb74c0ac7b9245b1788c7acc038
+    url: https://assets.bonsai.sensu.io/a2299af95a4fa0aed9da508f70262eab4b971b52/sensu-rocketchat-handler_0.1.0_windows_amd64.tar.gz
+  - filters:
+    - entity.system.os == 'darwin'
+    - entity.system.arch == 'amd64'
+    headers: null
+    sha512: 5ee04dae0e05ac6746de06f5966b28057c011395bdc930b46ae60e1d8168cfb6ef193ace1fd17563f6008cdb320c8aa4f0b59aac820d76cbe24e39aff3140d69
+    url: https://assets.bonsai.sensu.io/a2299af95a4fa0aed9da508f70262eab4b971b52/sensu-rocketchat-handler_0.1.0_darwin_amd64.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'arm'
+    - entity.system.arm_version == 6
+    headers: null
+    sha512: b7800ab1b15e92b35a8154fdd4cfca57086c05f4ce479fd40e2cc6787fbe257645cb889e36863c893a8346edf3afcc4bf6fda6d28d48b01e29b163c990b02c9c
+    url: https://assets.bonsai.sensu.io/a2299af95a4fa0aed9da508f70262eab4b971b52/sensu-rocketchat-handler_0.1.0_linux_armv6.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'arm'
+    - entity.system.arm_version == 7
+    headers: null
+    sha512: 695c82e4be6a2be6623027a5ef8189b36a615353c0411e5038b6d066e50373811d79172a8c2c71f9fbdcc6975a37aa21b3e77bf63cc3ba163209f9985de7534b
+    url: https://assets.bonsai.sensu.io/a2299af95a4fa0aed9da508f70262eab4b971b52/sensu-rocketchat-handler_0.1.0_linux_armv7.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'arm64'
+    headers: null
+    sha512: fba3f70db5925d59c2664777b88d5f1623ebfd12479406c133d9f5f4323e82b6ed998e751abe14579388412cdaffec981f21a8e2d0fc28e45b74d1010103e9b2
+    url: https://assets.bonsai.sensu.io/a2299af95a4fa0aed9da508f70262eab4b971b52/sensu-rocketchat-handler_0.1.0_linux_arm64.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == '386'
+    headers: null
+    sha512: ee658b9e362ad3ef3b14e0b3cb889d823b10f390345cc01e02b7b1fb9c4adb321dedc878d3e542d081c16841babb7b3ea1067c53486de5928755b118b0dc12b1
+    url: https://assets.bonsai.sensu.io/a2299af95a4fa0aed9da508f70262eab4b971b52/sensu-rocketchat-handler_0.1.0_linux_386.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'
+    headers: null
+    sha512: 9e4337ca406e5aebf164cc6813ef58c2067db012aab8ee17d58f9bd1d464ae566942ce773513872e6fec6b08bc953fcbf72fcae29d45448985c96513d2665f53
+    url: https://assets.bonsai.sensu.io/a2299af95a4fa0aed9da508f70262eab4b971b52/sensu-rocketchat-handler_0.1.0_linux_amd64.tar.gz
+  filters: null
+  headers: null
 

--- a/config/sensu/seeds/rocketchat.yaml
+++ b/config/sensu/seeds/rocketchat.yaml
@@ -14,4 +14,36 @@ metadata:
 spec:
   provider: vault
   id: secret/sensu/rocketchat#id
+---
+type: Secret
+api_version: secrets/v1
+metadata:
+  name: rocketchat_user
+spec:
+  provider: vault
+  id: secret/sensu/rocketchat#user
+---
+type: Secret
+api_version: secrets/v1
+metadata:
+  name: rocketchat_password
+spec:
+  provider: vault
+  id: secret/sensu/rocketchat#password
+---
+type: Secret
+api_version: secrets/v1
+metadata:
+  name: rocketchat_url
+spec:
+  provider: vault
+  id: secret/sensu/rocketchat#url
+---
+type: Secret
+api_version: secrets/v1
+metadata:
+  name: rocketchat_channel
+spec:
+  provider: vault
+  id: secret/sensu/rocketchat#channel
 

--- a/docker-compose-cluster.yaml
+++ b/docker-compose-cluster.yaml
@@ -343,6 +343,60 @@ services:
     command: >-
       vault server -dev -log-level debug
 
+  # Chat
+  #
+  # Provide a Let's Chat service instance for use for alert notifications
+  # See: https://sdelements.github.io/lets-chat/
+  rocketchat:
+    image: registry.rocket.chat/rocketchat/rocket.chat:latest
+    ports:
+      - 5000:5000
+    depends_on:
+      - mongo
+    volumes:
+    - type: volume
+      source: rocketchat_data
+      target: /app/uploads
+      consistency: consistent
+    environment:
+      - PORT=5000
+      - ROOT_URL=http://localhost:5000
+      - MONGO_URL=mongodb://mongo:27017/rocketchat
+      - MONGO_OPLOG_URL=mongodb://mongo:27017/local
+      - ADMIN_USERNAME=$ROCKETCHAT_ADMIN_USER
+      - ADMIN_PASS=$ROCKETCHAT_ADMIN_PASSWORD
+      - ADMIN_EMAIL=admin@example.com
+      - OVERWRITE_SETTING_Show_Setup_Wizard=completed
+      - CREATE_TOKENS_FOR_USERS=true
+
+  # Mongo
+  # Provides a mongoDB intance for use by chat service
+  mongo:
+    image: mongo:4.0
+    command: mongod --smallfiles --oplogSize 128 --replSet rs0 --storageEngine=mmapv1
+    volumes:
+    - type: volume
+      source: mongo_data
+      target: /data/db
+      consistency: consistent
+  mongo-init-replica:
+    image: mongo:4.0
+    command: >
+      bash -c
+        "for i in `seq 1 30`; do
+          mongo mongo/rocketchat --eval \"
+            rs.initiate({
+              _id: 'rs0',
+              members: [ { _id: 0, host: 'localhost:27017' } ]})\" &&
+          s=$$? && break || s=$$?;
+          echo \"Tried $$i times. Waiting 5 secs...\";
+          sleep 5;
+        done; (exit $$s)"
+    depends_on:
+      - mongo
+      
+
+
   # Workstation
   #
   # Provide a clean workshop environment based on Alpine Linux w/ sensuctl
@@ -503,3 +557,8 @@ volumes:
     driver: local
   elasticsearch_data:
     driver: local
+  mongo_data:
+    driver: local
+  rocketchat_data:
+    driver: local
+

--- a/docker-compose-default.yaml
+++ b/docker-compose-default.yaml
@@ -218,6 +218,58 @@ services:
     command: >-
       vault server -dev -log-level debug
 
+  # Chat
+  #
+  # Provide a Let's Chat service instance for use for alert notifications
+  # See: https://sdelements.github.io/lets-chat/
+  rocketchat:
+    image: registry.rocket.chat/rocketchat/rocket.chat:latest
+    ports:
+      - 5000:5000
+    depends_on:
+      - mongo
+    volumes:
+    - type: volume
+      source: rocketchat_data
+      target: /app/uploads
+      consistency: consistent
+    environment:
+      - PORT=5000
+      - ROOT_URL=http://localhost:5000
+      - MONGO_URL=mongodb://mongo:27017/rocketchat
+      - MONGO_OPLOG_URL=mongodb://mongo:27017/local
+      - ADMIN_USERNAME=$ROCKETCHAT_ADMIN_USER
+      - ADMIN_PASS=$ROCKETCHAT_ADMIN_PASSWORD
+      - ADMIN_EMAIL=admin@example.com
+      - OVERWRITE_SETTING_Show_Setup_Wizard=completed
+      - CREATE_TOKENS_FOR_USERS=true
+
+  # Mongo
+  # Provides a mongoDB intance for use by chat service
+  mongo:
+    image: mongo:4.0
+    command: mongod --smallfiles --oplogSize 128 --replSet rs0 --storageEngine=mmapv1
+    volumes:
+    - type: volume
+      source: mongo_data
+      target: /data/db
+      consistency: consistent
+  mongo-init-replica:
+    image: mongo:4.0
+    command: >
+      bash -c
+        "for i in `seq 1 30`; do
+          mongo mongo/rocketchat --eval \"
+            rs.initiate({
+              _id: 'rs0',
+              members: [ { _id: 0, host: 'localhost:27017' } ]})\" &&
+          s=$$? && break || s=$$?;
+          echo \"Tried $$i times. Waiting 5 secs...\";
+          sleep 5;
+        done; (exit $$s)"
+    depends_on:
+      - mongo
+
   # Workstation
   #
   # Provide a clean workshop environment based on Alpine Linux w/ sensuctl
@@ -370,4 +422,8 @@ volumes:
   prometheus_data:
     driver: local
   elasticsearch_data:
+    driver: local
+  mongo_data:
+    driver: local
+  rocketchat_data:
     driver: local

--- a/docker-compose-elasticsearch.yaml
+++ b/docker-compose-elasticsearch.yaml
@@ -234,6 +234,59 @@ services:
     command: >-
       vault server -dev -log-level debug
 
+  # Chat
+  #
+  # Provide a Let's Chat service instance for use for alert notifications
+  # See: https://sdelements.github.io/lets-chat/
+  rocketchat:
+    image: registry.rocket.chat/rocketchat/rocket.chat:latest
+    ports:
+      - 5000:5000
+    depends_on:
+      - mongo
+    volumes:
+    - type: volume
+      source: rocketchat_data
+      target: /app/uploads
+      consistency: consistent
+    environment:
+      - PORT=5000
+      - ROOT_URL=http://localhost:5000
+      - MONGO_URL=mongodb://mongo:27017/rocketchat
+      - MONGO_OPLOG_URL=mongodb://mongo:27017/local
+      - ADMIN_USERNAME=$ROCKETCHAT_ADMIN_USER
+      - ADMIN_PASS=$ROCKETCHAT_ADMIN_PASSWORD
+      - ADMIN_EMAIL=admin@example.com
+      - OVERWRITE_SETTING_Show_Setup_Wizard=completed
+      - CREATE_TOKENS_FOR_USERS=true
+
+  # Mongo
+  # Provides a mongoDB intance for use by chat service
+  mongo:
+    image: mongo:4.0
+    command: mongod --smallfiles --oplogSize 128 --replSet rs0 --storageEngine=mmapv1
+    volumes:
+    - type: volume
+      source: mongo_data
+      target: /data/db
+      consistency: consistent
+  mongo-init-replica:
+    image: mongo:4.0
+    command: >
+      bash -c
+        "for i in `seq 1 30`; do
+          mongo mongo/rocketchat --eval \"
+            rs.initiate({
+              _id: 'rs0',
+              members: [ { _id: 0, host: 'localhost:27017' } ]})\" &&
+          s=$$? && break || s=$$?;
+          echo \"Tried $$i times. Waiting 5 secs...\";
+          sleep 5;
+        done; (exit $$s)"
+    depends_on:
+      - mongo
+
+
   # Workstation
   #
   # Provide a clean workshop environment based on Alpine Linux w/ sensuctl
@@ -387,3 +440,8 @@ volumes:
     driver: local
   elasticsearch_data:
     driver: local
+  mongo_data:
+    driver: local
+  rocketchat_data:
+    driver: local
+      

--- a/docker-compose-prometheus.yaml
+++ b/docker-compose-prometheus.yaml
@@ -280,6 +280,60 @@ services:
     command: >-
       vault server -dev -log-level debug
 
+  # Chat
+  #
+  # Provide a Let's Chat service instance for use for alert notifications
+  # See: https://sdelements.github.io/lets-chat/
+  rocketchat:
+    image: registry.rocket.chat/rocketchat/rocket.chat:latest
+    ports:
+      - 5000:5000
+    depends_on:
+      - mongo
+    volumes:
+    - type: volume
+      source: rocketchat_data
+      target: /app/uploads
+      consistency: consistent
+    environment:
+      - PORT=5000
+      - ROOT_URL=http://localhost:5000
+      - MONGO_URL=mongodb://mongo:27017/rocketchat
+      - MONGO_OPLOG_URL=mongodb://mongo:27017/local
+      - ADMIN_USERNAME=$ROCKETCHAT_ADMIN_USER
+      - ADMIN_PASS=$ROCKETCHAT_ADMIN_PASSWORD
+      - ADMIN_EMAIL=admin@example.com
+      - OVERWRITE_SETTING_Show_Setup_Wizard=completed
+      - CREATE_TOKENS_FOR_USERS=true
+
+
+  # Mongo
+  # Provides a mongoDB intance for use by chat service
+  mongo:
+    image: mongo:4.0
+    command: mongod --smallfiles --oplogSize 128 --replSet rs0 --storageEngine=mmapv1
+    volumes:
+    - type: volume
+      source: mongo_data
+      target: /data/db
+      consistency: consistent
+  mongo-init-replica:
+    image: mongo:4.0
+    command: >
+      bash -c
+        "for i in `seq 1 30`; do
+          mongo mongo/rocketchat --eval \"
+            rs.initiate({
+              _id: 'rs0',
+              members: [ { _id: 0, host: 'localhost:27017' } ]})\" &&
+          s=$$? && break || s=$$?;
+          echo \"Tried $$i times. Waiting 5 secs...\";
+          sleep 5;
+        done; (exit $$s)"
+    depends_on:
+      - mongo
+
+
   # Workstation
   #
   # Provide a clean workshop environment based on Alpine Linux w/ sensuctl
@@ -433,3 +487,8 @@ volumes:
     driver: local
   elasticsearch_data:
     driver: local
+  mongo_data:
+    driver: local
+  rocketchat_data:
+    driver: local
+

--- a/docker-compose-timescaledb.yaml
+++ b/docker-compose-timescaledb.yaml
@@ -218,6 +218,59 @@ services:
     command: >-
       vault server -dev -log-level debug
 
+ # Chat
+  #
+  # Provide a Let's Chat service instance for use for alert notifications
+  # See: https://sdelements.github.io/lets-chat/
+  rocketchat:
+    image: registry.rocket.chat/rocketchat/rocket.chat:latest
+    ports:
+      - 5000:5000
+    depends_on:
+      - mongo
+    volumes:
+    - type: volume
+      source: rocketchat_data
+      target: /app/uploads
+      consistency: consistent
+    environment:
+      - PORT=5000
+      - ROOT_URL=http://localhost:5000
+      - MONGO_URL=mongodb://mongo:27017/rocketchat
+      - MONGO_OPLOG_URL=mongodb://mongo:27017/local
+      - ADMIN_USERNAME=$ROCKETCHAT_ADMIN_USER
+      - ADMIN_PASS=$ROCKETCHAT_ADMIN_PASSWORD
+      - ADMIN_EMAIL=admin@example.com
+      - OVERWRITE_SETTING_Show_Setup_Wizard=completed
+      - CREATE_TOKENS_FOR_USERS=true
+
+  # Mongo
+  # Provides a mongoDB intance for use by chat service
+  mongo:
+    image: mongo:4.0
+    command: mongod --smallfiles --oplogSize 128 --replSet rs0 --storageEngine=mmapv1
+    volumes:
+    - type: volume
+      source: mongo_data
+      target: /data/db
+      consistency: consistent
+  mongo-init-replica:
+    image: mongo:4.0
+    command: >
+      bash -c
+        "for i in `seq 1 30`; do
+          mongo mongo/rocketchat --eval \"
+            rs.initiate({
+              _id: 'rs0',
+              members: [ { _id: 0, host: 'localhost:27017' } ]})\" &&
+          s=$$? && break || s=$$?;
+          echo \"Tried $$i times. Waiting 5 secs...\";
+          sleep 5;
+        done; (exit $$s)"
+    depends_on:
+      - mongo
+
+
   # Workstation
   #
   # Provide a clean workshop environment based on Alpine Linux w/ sensuctl
@@ -371,3 +424,8 @@ volumes:
     driver: local
   elasticsearch_data:
     driver: local
+  mongo_data:
+    driver: local
+  rocketchat_data:
+    driver: local
+

--- a/lessons/operator/04/README.md
+++ b/lessons/operator/04/README.md
@@ -109,6 +109,7 @@ spec:
   type: set
   handlers:
   - email
+  - rocketchat
   - slack
   - microsoft-teams
 ```

--- a/lessons/operator/04/README.md
+++ b/lessons/operator/04/README.md
@@ -211,7 +211,7 @@ For more information on configuration overrides via check and entity annotations
        sensu-rocketchat-handler
        --url ${ROCKETCHAT_URL}
        --channel ${ROCKETCHAT_CHANNEL}
-       --username ${ROCKETCHAT_USER}
+       --user ${ROCKETCHAT_USER}
        --description-template "{{ .Check.Output }}\n\n[namespace: {{.Entity.Namespace}}]"
      runtime_assets:
      - sensu/sensu-rocketchat-handler:0.1.0

--- a/lessons/operator/05/README.md
+++ b/lessons/operator/05/README.md
@@ -287,7 +287,7 @@ _NOTE: dead man's switches are covered in more detail in [Lesson 7: Introduction
 
 ## EXERCISE 2: create an event that triggers an alert
 
-Sensu matches incoming events with the corresponding event pipelines using an event attribute called `handlers` (e.g. `handlers:["slack","pagerduty"]`).
+Sensu matches incoming events with the corresponding event pipelines using an event attribute called `handlers` (e.g. `handlers:["rocketchat","pagerduty"]`).
 Let's create an event that will be processed using the handler we configured in [Lesson 4](/lessons/04/README.md#readme).
 
 1. **Configure environment variables.**
@@ -316,9 +316,9 @@ Let's create an event that will be processed using the handler we configured in 
 1. **Create an event using shell commands and the Sensu Events API.**
 
    Do you notice anything different about the contents of the event in the next step?
-   There's an additional property called `handlers: ["slack"]` that provides instructions on which pipeline(s) Sensu should use to process the event (in this case, the Slack handler we configured in Lesson 4).
+   There's an additional property called `handlers: ["rocketchat"]` that provides instructions on which pipeline(s) Sensu should use to process the event (in this case, the RocketChat handler we configured in Lesson 4).
    If the `handlers` property is omitted from an event, Sensu will simply store the event and no additional processing will be performed.
-   Run the following command to create an event that will be processed using our Slack handler.
+   Run the following command to create an event that will be processed using our RocketChat handler.
 
    **Mac and Linux users:**
 
@@ -326,7 +326,7 @@ Let's create an event that will be processed using the handler we configured in 
    curl \
      -i -X POST -H "Authorization: Key ${SENSU_API_KEY}" \
      -H "Content-Type: application/json" \
-     -d '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-app"},"interval":30,"status":2,"output":"ERROR: failed to connect to database.","handlers":["slack"]}}' \
+     -d '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-app"},"interval":30,"status":2,"output":"ERROR: failed to connect to database.","handlers":["rocketchat"]}}' \
      "${SENSU_API_URL:-http://127.0.0.1:8080}/api/core/v2/namespaces/${SENSU_NAMESPACE:-default}/events"
    ```
 
@@ -337,7 +337,7 @@ Let's create an event that will be processed using the handler we configured in 
      -Method POST `
      -Headers @{"Authorization" = "Key ${Env:SENSU_API_KEY}";} `
      -ContentType "application/json" `
-     -Body '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-app"},"interval":30,"status":2,"output":"ERROR: failed to connect to database.","handlers":["slack"]}}' `
+     -Body '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-app"},"interval":30,"status":2,"output":"ERROR: failed to connect to database.","handlers":["rocketchat"]}}' `
      -Uri "${Env:SENSU_API_URL}/api/core/v2/namespaces/${Env:SENSU_NAMESPACE}/events"
    ```
 
@@ -351,7 +351,7 @@ Let's create an event that will be processed using the handler we configured in 
    curl \
      -i -X POST -H "Authorization: Key ${SENSU_API_KEY}" \
      -H "Content-Type: application/json" \
-     -d '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-app"},"interval":30,"status":0,"output":"200 OK","handlers":["slack"]}}' \
+     -d '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-app"},"interval":30,"status":0,"output":"200 OK","handlers":["rocketchat"]}}' \
      "${SENSU_API_URL:-http://127.0.0.1:8080}/api/core/v2/namespaces/${SENSU_NAMESPACE:-default}/events"
    ```
 
@@ -362,12 +362,13 @@ Let's create an event that will be processed using the handler we configured in 
      -Method POST `
      -Headers @{"Authorization" = "Key ${Env:SENSU_API_KEY}";} `
      -ContentType "application/json" `
-     -Body '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-app"},"interval":30,"status":0,"output":"200 OK","handlers":["slack"]}}' `
+     -Body '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-app"},"interval":30,"status":0,"output":"200 OK","handlers":["rocketchat"]}}' `
      -Uri "${Env:SENSU_API_URL}/api/core/v2/namespaces/${Env:SENSU_NAMESPACE}/events"
    ```
 
-**NEXT:** Did Sensu create messages in Slack?
+**NEXT:** Did Sensu create messages in RocketChat?
 If so you're ready to move on to the next step!
+Note: self-guided workshop users can login to the workshop provided Rocketchat instance at `http://127.0.0.1:5000` with `user: trainee` `password: workshop`. 
 
 ## Learn more
 

--- a/lessons/operator/06/README.md
+++ b/lessons/operator/06/README.md
@@ -24,7 +24,7 @@ Some example use cases include:
 - **Eliminating alert fatigue** by deduplicating incoming events and limiting repeat processing to predefined conditions (e.g. only alert once per hour per incident)
 - **Optimizing metrics processing** by dropping events that do not contain metric data, or sampling metrics to reduce storage costs
 - **Orchestrating event processing** via occurrence filtering (e.g. trigger a lightweight remediation action after 3 occurrences, and a more aggressive remediation action after 10+ occurrences)
-- **Configuring conditional triggers** by evaluating incoming events to determine which event handler to use (e.g. notify developers via Slack, but send all incidents assigned to operations via Pagerduty using a handler set and corresponding filters)
+- **Configuring conditional triggers** by evaluating incoming events to determine which event handler to use (e.g. notify developers via RocketChat, but send all incidents assigned to operations via Pagerduty using a handler set and corresponding filters)
 
 ## Filter execution environment & built-in helper functions
 
@@ -53,7 +53,7 @@ Let's use a built-in filter with a handler we configured in [Lesson 4](/lessons/
 
 1. **Modify a handler configuration template to use a built-in filter.**
 
-   Let's modify the handler template we created in [Lesson 4](/lessons/operator/04/README.md#readme) (i.e. `slack.yaml`), and replace the `filters: []` line with the following:
+   Let's modify the handler template we created in [Lesson 4](/lessons/operator/04/README.md#readme) (i.e. `rocketchat.yaml`), and replace the `filters: []` line with the following:
 
    ```yaml
    filters:
@@ -63,13 +63,13 @@ Let's use a built-in filter with a handler we configured in [Lesson 4](/lessons/
 1. **Update the handler using `sensuctl create -f`.**
 
    ```shell
-   sensuctl create -f slack.yaml
+   sensuctl create -f rocketchat.yaml
    ```
 
    Now verify that the handler configuration was updated by viewing the handler using `sensuctl` or the Sensu web app.
 
    ```shell
-   sensuctl handler info slack --format yaml
+   sensuctl handler info rocketchat --format yaml
    ```
 
 1. **Configure environment variables.**
@@ -107,7 +107,7 @@ Let's use a built-in filter with a handler we configured in [Lesson 4](/lessons/
    ```shell
    curl -i -X POST -H "Authorization: Key ${SENSU_API_KEY}" \
         -H "Content-Type: application/json" \
-        -d '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-app"},"interval":30,"status":0,"output":"200 OK","handlers":["slack"]}}' \
+        -d '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-app"},"interval":30,"status":0,"output":"200 OK","handlers":["rocketchat"]}}' \
         "${SENSU_API_URL:-http://127.0.0.1:8080}/api/core/v2/namespaces/${SENSU_NAMESPACE:-default}/events"
    ```
 
@@ -118,7 +118,7 @@ Let's use a built-in filter with a handler we configured in [Lesson 4](/lessons/
      -Method POST `
      -Headers @{"Authorization" = "Key ${Env:SENSU_API_KEY}";} `
      -ContentType "application/json" `
-     -Body '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-app"},"interval":30,"status":0,"output":"200 OK","handlers":["slack"]}}' `
+     -Body '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-app"},"interval":30,"status":0,"output":"200 OK","handlers":["rocketchat"]}}' `
      -Uri "${Env:SENSU_API_URL}/api/core/v2/namespaces/${Env:SENSU_NAMESPACE}/events"
    ```
 
@@ -129,7 +129,7 @@ Let's use a built-in filter with a handler we configured in [Lesson 4](/lessons/
    ```shell
    curl -i -X POST -H "Authorization: Key ${SENSU_API_KEY}" \
         -H "Content-Type: application/json" \
-        -d '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-app"},"interval":30,"status":2,"output":"ERROR: failed to connect to database.","handlers":["slack"]}}' \
+        -d '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-app"},"interval":30,"status":2,"output":"ERROR: failed to connect to database.","handlers":["rocketchat"]}}' \
         "${SENSU_API_URL:-http://127.0.0.1:8080}/api/core/v2/namespaces/${SENSU_NAMESPACE:-default}/events"
    ```
 
@@ -140,7 +140,7 @@ Let's use a built-in filter with a handler we configured in [Lesson 4](/lessons/
      -Method POST `
      -Headers @{"Authorization" = "Key ${Env:SENSU_API_KEY}";} `
      -ContentType "application/json" `
-     -Body '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-app"},"interval":30,"status":2,"output":"ERROR: failed to connect to database.","handlers":["slack"]}}' `
+     -Body '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-app"},"interval":30,"status":2,"output":"ERROR: failed to connect to database.","handlers":["rocketchat"]}}' `
      -Uri "${Env:SENSU_API_URL}/api/core/v2/namespaces/${Env:SENSU_NAMESPACE}/events"
    ```
 
@@ -198,7 +198,7 @@ Let's use a built-in filter with a handler we configured in [Lesson 4](/lessons/
 
 1. **Modify a handler configuration template to use a custom filter.**
 
-   Let's modify the handler template we created in [Lesson 4](/lessons/operator/04/README.md#readme) (i.e. `slack.yaml`), and update the `filters` field with the following:
+   Let's modify the handler template we created in [Lesson 4](/lessons/operator/04/README.md#readme) (i.e. `rocketchat.yaml`), and update the `filters` field with the following:
 
    ```yaml
    filters:
@@ -209,13 +209,13 @@ Let's use a built-in filter with a handler we configured in [Lesson 4](/lessons/
 1. **Update the handler using `sensuctl create -f`.**
 
    ```shell
-   sensuctl create -f slack.yaml
+   sensuctl create -f rocketchat.yaml
    ```
 
    Now verify that the handler configuration was updated by viewing the handler using `sensuctl` or the Sensu web app.
 
    ```shell
-   sensuctl handler info slack --format yaml
+   sensuctl handler info rocketchat --format yaml
    ```
 
 1. **Configure environment variables.**
@@ -253,7 +253,7 @@ Let's use a built-in filter with a handler we configured in [Lesson 4](/lessons/
    ```shell
    curl -i -X POST -H "Authorization: Key ${SENSU_API_KEY}" \
         -H "Content-Type: application/json" \
-        -d '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-api"},"interval":30,"status":2,"output":"ERROR: failed to connect to database.","handlers":["slack"]}}' \
+        -d '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-api"},"interval":30,"status":2,"output":"ERROR: failed to connect to database.","handlers":["rocketchat"]}}' \
         "${SENSU_API_URL:-http://127.0.0.1:8080}/api/core/v2/namespaces/${SENSU_NAMESPACE:-default}/events"
    ```
 
@@ -264,7 +264,7 @@ Let's use a built-in filter with a handler we configured in [Lesson 4](/lessons/
      -Method POST `
      -Headers @{"Authorization" = "Key ${Env:SENSU_API_KEY}";} `
      -ContentType "application/json" `
-     -Body '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-api"},"interval":30,"status":2,"output":"ERROR: failed to connect to database.","handlers":["slack"]}}' `
+     -Body '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-api"},"interval":30,"status":2,"output":"ERROR: failed to connect to database.","handlers":["rocketchat"]}}' `
      -Uri "${Env:SENSU_API_URL}/api/core/v2/namespaces/${Env:SENSU_NAMESPACE}/events"
    ```
 
@@ -275,7 +275,7 @@ Let's use a built-in filter with a handler we configured in [Lesson 4](/lessons/
    ```shell
    curl -i -X POST -H "Authorization: Key ${SENSU_API_KEY}" \
         -H "Content-Type: application/json" \
-        -d '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-api"},"interval":30,"status":2,"output":"ERROR: failed to connect to database.","handlers":["slack"]}}' \
+        -d '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-api"},"interval":30,"status":2,"output":"ERROR: failed to connect to database.","handlers":["rocketchat"]}}' \
         "${SENSU_API_URL:-http://127.0.0.1:8080}/api/core/v2/namespaces/${SENSU_NAMESPACE:-default}/events"
    ```
 
@@ -286,7 +286,7 @@ Let's use a built-in filter with a handler we configured in [Lesson 4](/lessons/
      -Method POST `
      -Headers @{"Authorization" = "Key ${Env:SENSU_API_KEY}";} `
      -ContentType "application/json" `
-     -Body '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-api"},"interval":30,"status":2,"output":"ERROR: failed to connect to database.","handlers":["slack"]}}' `
+     -Body '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-api"},"interval":30,"status":2,"output":"ERROR: failed to connect to database.","handlers":["rocketchat"]}}' `
      -Uri "${Env:SENSU_API_URL}/api/core/v2/namespaces/${Env:SENSU_NAMESPACE}/events"
    ```
 
@@ -297,7 +297,7 @@ Let's use a built-in filter with a handler we configured in [Lesson 4](/lessons/
    ```shell
    curl -i -X POST -H "Authorization: Key ${SENSU_API_KEY}" \
         -H "Content-Type: application/json" \
-        -d '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-api"},"interval":30,"status":0,"output":"200 OK","handlers":["slack"]}}' \
+        -d '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-api"},"interval":30,"status":0,"output":"200 OK","handlers":["rocketchat"]}}' \
         "${SENSU_API_URL:-http://127.0.0.1:8080}/api/core/v2/namespaces/${SENSU_NAMESPACE:-default}/events"
    ```
 
@@ -308,7 +308,7 @@ Let's use a built-in filter with a handler we configured in [Lesson 4](/lessons/
      -Method POST `
      -Headers @{"Authorization" = "Key ${Env:SENSU_API_KEY}";} `
      -ContentType "application/json" `
-     -Body '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-api"},"interval":30,"status":0,"output":"200 OK","handlers":["slack"]}}' `
+     -Body '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-api"},"interval":30,"status":0,"output":"200 OK","handlers":["rocketchat"]}}' `
      -Uri "${Env:SENSU_API_URL}/api/core/v2/namespaces/${Env:SENSU_NAMESPACE}/events"
    ```
 
@@ -319,7 +319,7 @@ Let's use a built-in filter with a handler we configured in [Lesson 4](/lessons/
    ```shell
    curl -i -X POST -H "Authorization: Key ${SENSU_API_KEY}" \
         -H "Content-Type: application/json" \
-        -d '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-api"},"interval":30,"status":0,"output":"200 OK","handlers":["slack"]}}' \
+        -d '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-api"},"interval":30,"status":0,"output":"200 OK","handlers":["rocketchat"]}}' \
         "${SENSU_API_URL:-http://127.0.0.1:8080}/api/core/v2/namespaces/${SENSU_NAMESPACE:-default}/events"
    ```
 
@@ -330,7 +330,7 @@ Let's use a built-in filter with a handler we configured in [Lesson 4](/lessons/
      -Method POST `
      -Headers @{"Authorization" = "Key ${Env:SENSU_API_KEY}";} `
      -ContentType "application/json" `
-     -Body '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-api"},"interval":30,"status":0,"output":"200 OK","handlers":["slack"]}}' `
+     -Body '{"entity":{"metadata":{"name":"i-424242"}},"check":{"metadata":{"name":"my-api"},"interval":30,"status":0,"output":"200 OK","handlers":["rocketchat"]}}' `
      -Uri "${Env:SENSU_API_URL}/api/core/v2/namespaces/${Env:SENSU_NAMESPACE}/events"
    ```
 

--- a/lessons/operator/07/README.md
+++ b/lessons/operator/07/README.md
@@ -597,7 +597,8 @@ Let's stop our agent and modify its configuration:
      foo: bar
      environment: training
    annotations:
-     sensu.io/plugins/slack/config/username: sensu-trainee
+     sensu.io/plugins/rockerchat/config/alias: sensu-trainee
+
    deregister: true
    ```
 

--- a/lessons/operator/09/README.md
+++ b/lessons/operator/09/README.md
@@ -56,6 +56,7 @@ spec:
     - unknown:
         - nginx-config-validation
   handlers:
+    - rocketchat
     - slack
 ```
 

--- a/scripts/seed-workshop-resources
+++ b/scripts/seed-workshop-resources
@@ -12,7 +12,10 @@ VAULT_ADDR=${VAULT_ADDR:-"http://vault:8200"}
 VAULT_DEV_ROOT_TOKEN_ID=${VAULT_DEV_ROOT_TOKEN_ID:-"secretsmanager"}
 VAULT_SECRET_PATH_PREFIX=${VAULT_SECRET_PATH_PREFIX:-"secret/sensu"}
 VAULT_WORKSHOP_SEEDS=${VAULT_WORKSHOP_SEEDS:-"config/vault/secrets"}
-
+ROCKETCHAT_ADDR=${ROCKETCHAT_ADDR:-"http://rocketchat:5000"}
+ROCKETCHAT_ADMIN_USER=${ROCKETCHAT_ADMIN_USER:-"admin"}
+ROCKETCHAT_ADMIN_PASSWORD=${ROCKETCHAT_ADMIN_PASSWORD:-"admin"}
+ROCKETCHAT_USER_PASSWORD=${WORKSHOP_PASSWORD:-"workshop"}
 check_deps() {
   for DEP in sensuctl vault
   do
@@ -73,6 +76,48 @@ seed_namespaces() {
   done
 }
 
+seed_chat_users() {
+	result=$(curl -s -XPOST ${ROCKETCHAT_ADDR}/api/v1/login -d "user=${ROCKETCHAT_ADMIN_USER}&password=${ROCKETCHAT_ADMIN_PASSWORD}") 
+	if [ $? -gt 0 ]; then
+  		echo "Failed to auth with rocketchat"
+  		echo ""
+  		exit 2
+	fi
+	token=$(echo $result | jq -r .data.authToken)
+	id=$(echo $result | jq -r .data.userId)
+	echo "Rocket Chat Admin Token: ${token}"
+	echo "Rocket Chat Admin Id: ${id}"
+	curl -s -H "X-Auth-Token: ${token}" -H "X-User-Id: ${id}" ${ROCKETCHAT_ADDR}/api/v1/me > /dev/null
+	if [ $? -gt 0 ]; then
+  		echo "rocketchat token/id are invalid"
+  		echo ""
+  		exit 2
+	fi
+  	for USER in $( cat "${USERS_JSON}" | jq -r '.[] | @base64' | sort -u); do
+    		export USERNAME_ORIGINAL=$(echo ${USER} | base64 -d | jq -r .username)
+    		export USERNAME=$(echo ${USERNAME_ORIGINAL} | awk -F "@" '{print $1}')
+	        result=$(curl -sS -H "X-Auth-Token: ${token}" \
+                     -H "X-User-Id: ${id}" \
+                     -H "Content-type:application/json" \
+                     ${ROCKETCHAT_ADDR}/api/v1/users.create \
+		     -d "{\"name\": \"${USERNAME}\", \"email\": \"${USERNAME_ORIGINAL}\", \"password\": \"${ROCKETCHAT_USER_PASSWORD}\", \"username\": \"${USERNAME}\"}")
+		if [ $? -gt 0 ]; then
+  			echo "rocketchat user not created for $USERNAME"
+  			echo ""
+  			exit 2
+		fi
+	        result=$(curl -sS -H "X-Auth-Token: ${token}" \
+                     -H "X-User-Id: ${id}" \
+                     -H "Content-type:application/json" \
+		     ${ROCKETCHAT_ADDR}/api/v1/users.getStatus?username=${USERNAME})
+		if [ $(echo $result | jq -r .success) != "true" ]; then
+  			echo "rocketchat user not created for $USERNAME"
+  			echo ""
+  			exit 2
+		fi
+	done
+}
+
 seed_user_envrc_files() {
   for USER in $( cat "${USERS_JSON}" | jq -r '.[] | @base64' | sort -u); do
     export USERNAME_ORIGINAL=$(echo ${USER} | base64 -d | jq -r .username)
@@ -97,6 +142,22 @@ seed_secrets() {
     vault kv put ${VAULT_SECRET_PATH_PREFIX}/${NAME} @${VAULT_WORKSHOP_SEEDS}/${SECRET} > /dev/null 2>&1
     vault kv get --format json ${VAULT_SECRET_PATH_PREFIX}/${NAME} | jq .data.data
   done
+
+
+
+  result=$(curl -s -XPOST ${ROCKETCHAT_ADDR}/api/v1/login -d "user=${ROCKETCHAT_ADMIN_USER}&password=${ROCKETCHAT_ADMIN_PASSWORD}") 
+  if [ $? -gt 0 ]; then
+  	echo "Failed to auth with rocketchat"
+  	echo ""
+  	exit 2
+  fi
+  rc_token=$(echo $result | jq -r .data.authToken)
+  rc_id=$(echo $result | jq -r .data.userId)
+  echo "Seeding Vault with secret key: ${VAULT_SECRET_PATH_PREFIX}/rocketchat"
+  vault kv put ${VAULT_SECRET_PATH_PREFIX}/rocketchat token=${rc_token} id=${rc_id} > /dev/null 2>&1
+  vault kv get --format json ${VAULT_SECRET_PATH_PREFIX}/rocketchat | jq .data.data
+
+	
 }
 
 echo "Seeding Sensu Go Workshop resources..."
@@ -106,12 +167,15 @@ if [ $? -gt 0 ]; then
   echo ""
   exit 2
 fi
+
+
 check_deps && \
 validate_io && \
 validate_api_urls && \
 seed_cluster && \
 seed_namespaces && \
 seed_user_envrc_files && \
+seed_chat_users && \
 seed_secrets
 if [ $? -gt 0 ]; then
   echo "Failed to create Sensu user accounts."

--- a/scripts/seed-workshop-resources
+++ b/scripts/seed-workshop-resources
@@ -115,6 +115,16 @@ seed_chat_users() {
   			echo ""
   			exit 2
 		fi
+	        result=$(curl -sS -H "X-Auth-Token: ${token}" \
+                     -H "X-User-Id: ${id}" \
+                     -H "Content-type:application/json" \
+		     ${ROCKETCHAT_ADDR}/api/v1/roles.addUserToRole \
+		     -d "{ \"roleName\": \"bot\" , \"username\": \"${USERNAME}\" }")
+		if [ $(echo $result | jq -r .success) != "true" ]; then
+  			echo "rocketchat user $USERNAME not added to role bot"
+  			echo ""
+  			exit 2
+		fi
 	done
 }
 

--- a/scripts/seed-workshop-resources
+++ b/scripts/seed-workshop-resources
@@ -93,6 +93,16 @@ seed_chat_users() {
   		echo ""
   		exit 2
 	fi
+	result=$(curl -sS -H "X-Auth-Token: ${token}" \
+             -H "X-User-Id: ${id}" \
+             -H "Content-type:application/json" \
+	     ${ROCKETCHAT_ADDR}/api/v1/roles.addUserToRole \
+	     -d "{ \"roleName\": \"bot\" , \"username\": \"admin\" }")
+ 	if [ $(echo $result | jq -r .success) != "true" ]; then
+  		echo "rocketchat user admin not added to role bot"
+  		echo ""
+  		exit 2
+	fi
   	for USER in $( cat "${USERS_JSON}" | jq -r '.[] | @base64' | sort -u); do
     		export USERNAME_ORIGINAL=$(echo ${USER} | base64 -d | jq -r .username)
     		export USERNAME=$(echo ${USERNAME_ORIGINAL} | awk -F "@" '{print $1}')

--- a/scripts/seed-workshop-resources
+++ b/scripts/seed-workshop-resources
@@ -173,8 +173,12 @@ seed_secrets() {
   fi
   rc_token=$(echo $result | jq -r .data.authToken)
   rc_id=$(echo $result | jq -r .data.userId)
+  rc_user=${ROCKETCHAT_ADMIN_USER}
+  rc_password=${ROCKETCHAT_ADMIN_PASSWORD}
+  rc_channel="#general"
+  rc_url="http://rocketchat:5000"
   echo "Seeding Vault with secret key: ${VAULT_SECRET_PATH_PREFIX}/rocketchat"
-  vault kv put ${VAULT_SECRET_PATH_PREFIX}/rocketchat token=${rc_token} id=${rc_id} > /dev/null 2>&1
+  vault kv put ${VAULT_SECRET_PATH_PREFIX}/rocketchat url=${rc_url} token=${rc_token} id=${rc_id} user=${rc_user} password=${rc_password} channel=${rc_channel} > /dev/null 2>&1
   vault kv get --format json ${VAULT_SECRET_PATH_PREFIX}/rocketchat | jq .data.data
 
 	


### PR DESCRIPTION
- [X] Add rocket chat service to default docker-compose 
- [X] Seed rocket chat users
- [X] Seed rocket chat token secret into vault
- [X] Add rocker chat service to remaining docker-compose 
- [X] Add rocket chat handler using runtime asset built from sensu-rocketchat-handler repo
- [X] Update lesson plans with rocket chat instructions/screenshots replacing slack references.
