### PR TITLE
Re-org Lessons 7/8

### DIFF
--- a/config/sensu/seeds/disk.yaml
+++ b/config/sensu/seeds/disk.yaml
@@ -2,45 +2,45 @@
 type: Asset
 api_version: core/v2
 metadata:
-  name: sensu/check-disk-usage:0.4.2
-  labels:
+  name: sensu/check-disk-usage:0.5.0
+  labels: 
   annotations:
     io.sensu.bonsai.url: https://bonsai.sensu.io/assets/sensu/check-disk-usage
     io.sensu.bonsai.api_url: https://bonsai.sensu.io/api/v1/assets/sensu/check-disk-usage
     io.sensu.bonsai.tier: Community
-    io.sensu.bonsai.version: 0.4.2
+    io.sensu.bonsai.version: 0.5.0
     io.sensu.bonsai.namespace: sensu
     io.sensu.bonsai.name: check-disk-usage
     io.sensu.bonsai.tags: ''
 spec:
   builds:
-  - url: https://assets.bonsai.sensu.io/228613a4308320a8983fe133140a74bcce35dfa9/check-disk-usage_0.4.2_windows_amd64.tar.gz
-    sha512: f51438114cdace9d24ad0171b97fb16a1d3c6377d4cf4b990ab4f2732028cf33c0700ef1f1d266252d0f1bc1564d8197c9743c038f3dcf20f99e8ff711babf5e
+  - url: https://assets.bonsai.sensu.io/0759638733a16bab2996a0f9f32a7a13389d49d5/check-disk-usage_0.5.0_windows_amd64.tar.gz
+    sha512: 8d681f1c309434ad080b8fd715f4136edb55225bdcfb09bbd75d1586951f7b24086e8d1aa1dbb6e7d69ff917756652ead810d66f49506dccdd705e8f932c50a1
     filters:
     - entity.system.os == 'windows'
     - entity.system.arch == 'amd64'
-  - url: https://assets.bonsai.sensu.io/228613a4308320a8983fe133140a74bcce35dfa9/check-disk-usage_0.4.2_darwin_amd64.tar.gz
-    sha512: 89477eded109c47b6ccf783b1e1be388a1859b7ac591867f9e2a60f0cc5508a2495bb425864dfd230ba867be58da9ec4087635f79ad57314b7756be72830e9b7
+  - url: https://assets.bonsai.sensu.io/0759638733a16bab2996a0f9f32a7a13389d49d5/check-disk-usage_0.5.0_darwin_amd64.tar.gz
+    sha512: 0e39c7cabc0bc9423e61a57496668046ff40cf4845bd020fcbe4e325f4b47df95a1311bc51ad22d967200ba1a132618eec57aef3b6b166a92fc2362c484b4033
     filters:
     - entity.system.os == 'darwin'
     - entity.system.arch == 'amd64'
-  - url: https://assets.bonsai.sensu.io/228613a4308320a8983fe133140a74bcce35dfa9/check-disk-usage_0.4.2_linux_armv7.tar.gz
-    sha512: 9f626a38af27280681c77d634e47a5283baa8620134bf2ebb7cc7d0d5c3ed52b3403f21cf0907b298aa1d892e885ab8858987b0536e02003d2c6f4f59edff648
+  - url: https://assets.bonsai.sensu.io/0759638733a16bab2996a0f9f32a7a13389d49d5/check-disk-usage_0.5.0_linux_armv7.tar.gz
+    sha512: '0986873b105ed9ad2b0afde2fab770170c971cfd44451c9518f8475fa49df68940313ebda013b070dbea573689b56e89da87d875c8c98d8b85b566344b83f238'
     filters:
     - entity.system.os == 'linux'
     - entity.system.arch == 'armv7'
-  - url: https://assets.bonsai.sensu.io/228613a4308320a8983fe133140a74bcce35dfa9/check-disk-usage_0.4.2_linux_arm64.tar.gz
-    sha512: 0c042d697c27a7287a8091416a629720fedec600416630137841c359b8718d7ae600747b6cbfa983175d7456131f23c64f4b6b759c7367d0d6e5363078130c6a
+  - url: https://assets.bonsai.sensu.io/0759638733a16bab2996a0f9f32a7a13389d49d5/check-disk-usage_0.5.0_linux_arm64.tar.gz
+    sha512: d8646f15fe3afe64b9c546d9e7c37dbf4b0f1b75a7823deea574d085d109789bd27293196b1c5b60b9f1f4b81d19942ec5266509b2726ee4faed629a597f1a83
     filters:
     - entity.system.os == 'linux'
     - entity.system.arch == 'arm64'
-  - url: https://assets.bonsai.sensu.io/228613a4308320a8983fe133140a74bcce35dfa9/check-disk-usage_0.4.2_linux_386.tar.gz
-    sha512: 964b8c133b333d3c3e8b25ea7e17194d256979de7a6adc756285c9f37e1d72f6f1f52a1ddce07198a3751c9e9469f39d62476809286f2bfe6cda57ee89a28305
+  - url: https://assets.bonsai.sensu.io/0759638733a16bab2996a0f9f32a7a13389d49d5/check-disk-usage_0.5.0_linux_386.tar.gz
+    sha512: 68e0f2d3ca1fb4296db418d06f3c8162f8a84443464d167cafaf49e36ac9cf338737c7f34fa4f8861e0d47c930274e375ad0e49015ab895d64dd35301c5db4f8
     filters:
     - entity.system.os == 'linux'
     - entity.system.arch == '386'
-  - url: https://assets.bonsai.sensu.io/228613a4308320a8983fe133140a74bcce35dfa9/check-disk-usage_0.4.2_linux_amd64.tar.gz
-    sha512: 1dde2ae2acc342d0362a986e7f52a60ee8599d36072cf6138d1c7edd69631d6e46a7e9a2715df4fe545a9c49c4d354325cdb1cafd7a0c48a03c55c447ca77de6
+  - url: https://assets.bonsai.sensu.io/0759638733a16bab2996a0f9f32a7a13389d49d5/check-disk-usage_0.5.0_linux_amd64.tar.gz
+    sha512: 0a6b8d8d5fdd9e81650fc585bc066cf4f6e6784aa94abcec3023878cacec5d255306d19fc6e435c88ebd069636b891b99efe0c1923b2bc5d9de699740e6cc271
     filters:
     - entity.system.os == 'linux'
     - entity.system.arch == 'amd64'

--- a/lessons/operator/07/README.md
+++ b/lessons/operator/07/README.md
@@ -1,25 +1,24 @@
 # Lesson 7: Introduction to Agents
 
-- [Lesson 7: Introduction to Agents](#lesson-7-introduction-to-agents)
-  - [Goals](#goals)
-  - [The Sensu Agent](#the-sensu-agent)
-    - [Authentication and Communication](#authentication-and-communication)
-    - [EXERCISE 1: Install the Sensu Agent](#exercise-1-install-the-sensu-agent)
-      - [Scenario](#scenario)
-      - [Solution](#solution)
-      - [Steps](#steps)
-  - [Configuring the Agent](#configuring-the-agent)
-    - [Configuration Priority](#configuration-priority)
-    - [Configuration Names and Formats](#configuration-names-and-formats)
-    - [EXERCISE 2: Customize Agent Configuration](#exercise-2-customize-agent-configuration)
-      - [Scenario](#scenario-1)
-      - [Solution](#solution-1)
-      - [Steps](#steps-1)
-  - [Discussion](#discussion)
-    - [Multiple Configuration Methods](#multiple-configuration-methods)
-    - [Keepalives](#keepalives)
-  - [Learn More](#learn-more)
-  - [Next Steps](#next-steps)
+- [Goals](#goals)
+- [The Sensu Agent](#the-sensu-agent)
+  - [Authentication and Communication](#authentication-and-communication)
+  - [EXERCISE 1: Install the Sensu Agent](#exercise-1-install-the-sensu-agent)
+    - [Scenario](#scenario)
+    - [Solution](#solution)
+    - [Steps](#steps)
+- [Configuring the Agent](#configuring-the-agent)
+  - [Configuration Priority](#configuration-priority)
+  - [Configuration Names and Formats](#configuration-names-and-formats)
+  - [EXERCISE 2: Customize Agent Configuration](#exercise-2-customize-agent-configuration)
+    - [Scenario](#scenario-1)
+    - [Solution](#solution-1)
+    - [Steps](#steps-1)
+- [Discussion](#discussion)
+  - [Multiple Configuration Methods](#multiple-configuration-methods)
+  - [Keepalives](#keepalives)
+- [Learn More](#learn-more)
+- [Next Steps](#next-steps)
 
 ## Goals
 
@@ -46,12 +45,13 @@ For optimal network throughput, agents will attempt to negotiate the use of [Pro
 
 #### Scenario
 
-You have a server, container, or other device or piece of software that you want to manage with Sensu.
+You have a server, container, connected device, or service that you want to manage with Sensu.
 
 #### Solution
 
-Install the the Sensu Agent on the system. 
+Install a Sensu Agent. 
 The agent runs as a separate process that observes your system.
+It can run directly on the system you are observing, or anywhere on the network.
 Once it is installed, you can update its configuration and behavior dynamically without the need to redeploy.
 
 #### Steps
@@ -67,7 +67,7 @@ Once it is installed, you can update its configuration and behavior dynamically 
 > - `SENSU_USER`
 > - `SENSU_PASSWORD`
 > 
-> If any are missing, review the environment setup from [Lesson 3: Using the Sesnu CLI](../03/README.md#readme).
+> If any are missing, review the environment setup from [Lesson 3: Using the Sensu CLI](../03/README.md#readme).
 
 1. **Download & Install the Agent**
 
@@ -84,7 +84,7 @@ Once it is installed, you can update its configuration and behavior dynamically 
       curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/${SENSU_VERSION}/sensu-go_${SENSU_VERSION}_darwin_amd64.tar.gz
       ```
 
-      **Windows (PowerShell):**
+      **Windows (PowerShell)**
 
       ```powershell
       Invoke-WebRequest `
@@ -92,16 +92,10 @@ Once it is installed, you can update its configuration and behavior dynamically 
        -OutFile "${Env:UserProfile}\sensu-go-agent_${Env:SENSU_VERSION}.${Env:SENSU_BUILD}_en-US.x64.msi"
       ```
 
-      **Linux (amd64):**
+      **Linux**
 
       ```shell
       curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/${SENSU_VERSION}/sensu-go_${SENSU_VERSION}_linux_amd64.tar.gz 
-      ```
-
-      **Linux (arm64):**
-
-      ```shell
-      curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/${SENSU_VERSION}/sensu-go_${SENSU_VERSION}_linux_arm64.tar.gz
       ```
 
    2. **Install the Package and Cleanup**
@@ -118,7 +112,7 @@ Once it is installed, you can update its configuration and behavior dynamically 
       sudo mv sensu-agent /usr/local/bin/sensu-agent
       ```
 
-      **Windows (PowerShell):**
+      **Windows (PowerShell)**
 
       ```powershell
       msiexec.exe /i "${Env:UserProfile}\sensu-go-agent_${Env:SENSU_VERSION}.${Env:SENSU_BUILD}_en-US.x64.msi" /qr
@@ -126,18 +120,11 @@ Once it is installed, you can update its configuration and behavior dynamically 
       ${Env:Path} += ";C:\Program Files\Sensu\sensu-agent\bin"
       ```
 
-      **Linux (amd64):**
+      **Linux**
 
       ```shell
       sudo -E tar -xzf sensu-go_${SENSU_VERSION}_linux_amd64.tar.gz -C /usr/bin/
       rm sensu-go_${SENSU_VERSION}_linux_amd64.tar.gz
-      ```
-
-      **Linux (arm64):**
-
-      ```shell
-      sudo -E tar -xzf sensu-go_${SENSU_VERSION}_linux_arm64.tar.gz -C /usr/bin/
-      rm sensu-go_${SENSU_VERSION}_linux_arm64.tar.gz
       ```
 
 2. **Start the Agent.**
@@ -160,7 +147,7 @@ Once it is installed, you can update its configuration and behavior dynamically 
    --password ${SENSU_PASSWORD}
    ```
 
-   **Windows (PowerShell):**
+   **Windows (PowerShell)**
 
    ```powershell
    sensu-agent start `
@@ -173,7 +160,7 @@ Once it is installed, you can update its configuration and behavior dynamically 
    --password ${Env:SENSU_PASSWORD}
    ```
 
-   **Linux:**
+   **Linux**
 
    ```shell
    sudo -E sensu-agent start \
@@ -185,8 +172,16 @@ Once it is installed, you can update its configuration and behavior dynamically 
    --user ${SENSU_USER} \
    --password ${SENSU_PASSWORD}
    ```
+   
+1. ** Verify that your agent is running.** 
 
-   Verify that your agent is running and connected to the backend by running `sensuctl entity list`.
+   Verify that your agent is running and connected to the backend:
+
+   ```shell
+   sensuctl entity list
+   ```
+
+   You should see your machine in the entity list.
 
 **NEXT:** If `sensu-agent` has successfully connected to your backend, you're ready to move on to the next exercise.
 
@@ -210,62 +205,6 @@ If a configuration value is set in multiple places, it will be overrided with th
 2. **Environment Variable**
 3. **Configuration File**
 4. **Default Value** (lowest)
-
-### Configuration Names and Formats
-
-All of the agent configuration options have the same name regardless of the way they are set, differing only in format.
-
-For example, setting the namespace, backend url, and log level in all three formats is as follows:
-
-- **Command-Line Option:**
-
-  Pass the configuration option and the value using the format `--<option_name>=<value>`.
-  
-  - If the name of the configuration option has multiple words, separated the words with a dash (`-`).
-  - For options that can have a list of values, separate the values with commas and no spaces. 
-  
-  **Example:** Using Command-line Options for Configuration
-
-  ```shell
-  sensu-agent start --namespace=default --backend-url=ws://backend-1:8081,ws://backend-2:8081 --log-level=warn
-  ```
-  
-- **YAML Config File:**
-
-  Every configuration option has a corresponding YAML property. 
-  
-  - If the name of the configuration option has multiple words, separated the words with a dash (`-`).
-  - For options that can have a list of values, use the YAML list format.
-
-  **Example (`agent.yaml`):** Using a YAML Config File for Configuration
-
-  ```yaml
-  namespace: "default"
-  backend-url:
-    - "ws://backend-1:8081"
-    - "ws://backend-2:8081"
-  log-level: "warn"
-  ```
-  
-  To use the config file, pass the name of the config file via the `--config-file` option.  
-  
-  ```shell
-  sensu-agent start --config-file=agent.yaml
-  ```
-
-- **Environment Variable:**
-
-  Every configuration option also has a corresponding environment variable.
-  - All Sensu environment variable names are prefixed with `SENSU_`, followed by the corresponding option name in capitalized letters.
-  - Option values should be enclosed in quotes.
-  - If the name of the configuration option has multiple words, separated the words with an underscore (`_`).
-  - For options that can have a list of values, separate the values with a space (` `).
-
-  **Example:** Using Environment Variables for Configuration
-
-  ```shell
-  SENSU_NAMESPACE="default" SENSU_BACKEND_URL="ws://backend-1:8081 ws://backend-2:8081" SENSU_LOG_LEVEL="warn" sensu-agent start
-  ```
 
 In the next exercise, we will stop our agent and modify its configuration.
 
@@ -365,6 +304,62 @@ In the first exercise we passed all of the configuration via `sensu-agent start`
 The ability to configure the agent using multiple methods is very useful in complex environments that may have a mix of servers, compute instances, and containers. However, in practice you may find that just one method is best suited for your environment.
 
 For example, on Kubernetes or other container-based environments it may be easiest to manage all configuration via environment variables.
+
+### Configuration Names and Formats
+
+All of the agent configuration options use consistent naming regardless of the way they are set, differing only in format.
+
+For example, setting the namespace, backend url, and log level in all three formats is as follows:
+
+- **Command-Line Option:**
+
+  Pass the configuration option and the value using the format `--<option_name>=<value>`.
+  
+  - If the name of the configuration option has multiple words, separated the words with a dash (`-`).
+  - For options that can have a list of values, separate the values with commas and no spaces. 
+  
+  **Example:** Using Command-line Options for Configuration
+
+  ```shell
+  sensu-agent start --namespace=default --backend-url=ws://backend-1:8081,ws://backend-2:8081 --log-level=warn
+  ```
+  
+- **YAML Config File:**
+
+  Every configuration option has a corresponding YAML property. 
+  
+  - If the name of the configuration option has multiple words, separated the words with a dash (`-`).
+  - For options that can have a list of values, use the YAML list format.
+
+  **Example (`agent.yaml`):** Using a YAML Config File for Configuration
+
+  ```yaml
+  namespace: "default"
+  backend-url:
+    - "ws://backend-1:8081"
+    - "ws://backend-2:8081"
+  log-level: "warn"
+  ```
+  
+  To use the config file, pass the name of the config file via the `--config-file` option.  
+  
+  ```shell
+  sensu-agent start --config-file=agent.yaml
+  ```
+
+- **Environment Variable:**
+
+  Every configuration option also has a corresponding environment variable.
+  - All Sensu environment variable names are prefixed with `SENSU_`, followed by the corresponding option name in capitalized letters.
+  - Option values should be enclosed in quotes.
+  - If the name of the configuration option has multiple words, separated the words with an underscore (`_`).
+  - For options that can have a list of values, separate the values with a space (` `).
+
+  **Example:** Using Environment Variables for Configuration
+
+  ```shell
+  SENSU_NAMESPACE="default" SENSU_BACKEND_URL="ws://backend-1:8081 ws://backend-2:8081" SENSU_LOG_LEVEL="warn" sensu-agent start
+  ```
 
 ### Keepalives
 

--- a/lessons/operator/07/README.md
+++ b/lessons/operator/07/README.md
@@ -141,6 +141,7 @@ Once it is installed, you can update its configuration and behavior dynamically 
    --backend-url ${SENSU_BACKEND_URL} \
    --namespace ${SENSU_NAMESPACE} \
    --subscriptions system/macos,workshop \
+   --agent-managed-entity true \
    --deregister true \
    --cache-dir /opt/sensu/sensu-agent/cache \
    --user ${SENSU_USER} \
@@ -156,6 +157,7 @@ Once it is installed, you can update its configuration and behavior dynamically 
    --namespace ${Env:SENSU_NAMESPACE} `
    --subscriptions system/windows,workshop `
    --deregister true `
+   --agent-managed-entity true `
    --user ${Env:SENSU_USER} `
    --password ${Env:SENSU_PASSWORD}
    ```
@@ -169,6 +171,7 @@ Once it is installed, you can update its configuration and behavior dynamically 
    --namespace ${SENSU_NAMESPACE} \
    --subscriptions system/linux,workshop \
    --deregister true \
+   --agent-managed-entity true \
    --user ${SENSU_USER} \
    --password ${SENSU_PASSWORD}
    ```
@@ -249,6 +252,7 @@ Stop the agent, modify the configuration, then restart the agent.
    annotations:
      sensu.io/plugins/rocketchat/config/alias: sensu-trainee
 
+   agent-managed-entity: true
    deregister: true
    ```
 

--- a/lessons/operator/07/README.md
+++ b/lessons/operator/07/README.md
@@ -247,7 +247,7 @@ Stop the agent, modify the configuration, then restart the agent.
      foo: bar
      environment: training
    annotations:
-     sensu.io/plugins/rockerchat/config/alias: sensu-trainee
+     sensu.io/plugins/rocketchat/config/alias: sensu-trainee
 
    deregister: true
    ```

--- a/lessons/operator/08/README.md
+++ b/lessons/operator/08/README.md
@@ -69,7 +69,7 @@ Service checks can be written in any programming or scripting language, includin
 
 ### Subscriptions and Check Scheduling
 
-In Sensu, *subscriptions* are equivalent to topics in a traditional [pub/sub](https://en.wikipedia.org/wiki/Publish–subscribe_pattern) model. Agents are the subscribers and the backend is the publisher.
+In Sensu, *subscriptions* are equivalent to topics in a traditional [pub/sub](https://en.wikipedia.org/wiki/Publish–subscribe_pattern) model. The backend is the publisher and the agents is the subscriber.
 
 Checks are scheduled at pre-set intervals. The backend automatically publishes a request, and agents who are subscribed to the topic receive the request. The agent then performs the corresponding check, and sends the event data to the backend for processing via the observability pipeline.
 
@@ -165,8 +165,6 @@ Default values can also be provided as a fallback for [unmatched tokens](https:/
 - **`{{ .labels.url }}`:** replaced by the target entity "url" label
 - **`{{ .labels.disk_warning | default "85%" }}`:** replaced by the target entity "disk_warning" label; if the label is not set then the default/fallback value of `85%` will be used
 
-==TODO: add an example check config w/ .labels.disk_warning label==
-
 Tokens can be used to configure dynamic monitoring jobs (e.g. enabling node-based configuration overrides for things like alerting threshold, etc).
 
 Let's modify our check from the previous exercise using some tokens.
@@ -232,7 +230,7 @@ Then, we can use a token to read that value when the check is executed, and give
 
 1. TODO: Add annotation to an entity?
 
-## Metrics Collection and Extractions
+## Metrics Collection and Processing
 
 One common use case for checks is to collect system and service metrics (e.g. cpu, memory, or disk utilization; or api response times).
 
@@ -282,15 +280,17 @@ If an event containing metrics is configured with one or more `output_metric_han
 
 > **NOTE:** Checks may be configured with multiple `handlers` and `output_metric_handlers`, enabling service health checking, alerting, _and_ metrics collection in a single check.
 
-### EXERCISE 3: Tagging and Handling Metrics Using Checks
+### EXERCISE 3: Tagging and Processing Metrics Using Checks
 
 #### Scenario
 
-You have some existing metrics providers which provide output in Nagios format, which you want to store in InfluxDB. You also want to capture some additional information about the entity and have the metrics, along with it's context be handled by the pipeline.  
+You have some existing monitoring plugins which provide output in Nagios format, which you want to store in a data platform like Sumo Logic or InfluxDB. 
+You also want to capture some additional metadata about the server or service along with the metrics, and have it processed as a single unit by the pipeline.
 
 #### Solution
 
-This can be accomplished by configuring the check to expect Nagios format via the `output_metric_format` option, and configuring a metrics-specific storage handler via `output_metric_handlers`. We can also add additional metadata to the event using `output_metric_tags`.
+This can be accomplished by configuring the check to expect Nagios formatted metrics by using the `output_metric_format` option, and configuring a metrics-specific storage handler via `output_metric_handlers`. 
+We can also add additional metadata to the event using `output_metric_tags`.
 
 #### Steps
 

--- a/lessons/operator/08/README.md
+++ b/lessons/operator/08/README.md
@@ -232,7 +232,70 @@ Then, we can use a token to read that value when the check is executed, and give
    sensuctl check info disk-usage --format yaml
    ```
 
-1. TODO: Add annotation to an entity?
+1. **Update the Agent Configuration to Add Annotations.**
+
+   There are two ways to add the needed annotations, either by updating the entity configuration or the agent configuration.
+   In this exercise we will update the agent configuration.
+
+   1. **Stop the Agent**
+   
+      If you started your agent in the previous exercise using the `sensu-agent start` command, you can stop the agent by pressing `Control-C` in your terminal.
+      
+   1. **Edit the Agent Configuration**
+
+      In [Lesson 7](../07/README.md) we started an agent, and created a `agent.yaml` file containing most of its configuration.
+
+      Add `disk_usage_warning_threshold` and `disk_usage_critical_threshold` to the `annotations` list:
+
+      ```yaml
+      ---
+      backend_url: ws://127.0.0.1:8080
+      name: workshop
+      labels:
+        foo: bar
+        environment: training
+      annotations:
+        sensu.io/plugins/rockerchat/config/alias: sensu-trainee
+        disk_usage_warning_threshold: "50%"
+        disk_usage_critical_threshold: "70%"
+      deregister: true
+      ```
+      
+   2. **Restart the Agent.**
+
+      Let's start the agent from the command line, this time using a mix of environment variables and our configuration file.
+
+      **MacOS:**
+
+      ```shell
+      TMPDIR=/opt/sensu/tmp \
+      SENSU_SUBSCRIPTIONS="system/macos workshop" \
+      sudo -E sensu-agent start \
+      --config-file /opt/sensu/agent.yaml \
+      --cache-dir /opt/sensu/sensu-agent/cache \
+      --user ${SENSU_USER} \
+      --password ${SENSU_PASSWORD}
+      ```
+ 
+      **Windows (PowerShell):**
+ 
+      ```powershell
+      ${Env:SENSU_SUBSCRIPTIONS}="system/windows workshop" `
+      sensu-agent start `
+      --config-file "${Env:UserProfile}\Sensu\agent.yaml" `
+      --user ${Env:SENSU_USER} `
+      --password ${Env:SENSU_PASSWORD}
+      ```
+
+      **Linux:**
+
+      ```shell
+      SENSU_SUBSCRIPTIONS="system/linux workshop" \
+      sudo -E -u sensu sensu-agent start \
+      --config-file "/etc/sensu/agent.yaml" \
+      --user ${SENSU_USER} \
+      --password ${SENSU_PASSWORD}
+      ```
 
 ## Metrics Collection and Processing
 

--- a/lessons/operator/08/README.md
+++ b/lessons/operator/08/README.md
@@ -262,6 +262,7 @@ Then, we can use a token to read that value when the check is executed, and give
         sensu.io/plugins/rocketchat/config/alias: sensu-trainee
         disk_usage_warning_threshold: "50.0"
         disk_usage_critical_threshold: "70.0"
+      agent-managed-entity: true
       deregister: true
       ```
       

--- a/lessons/operator/08/README.md
+++ b/lessons/operator/08/README.md
@@ -20,6 +20,10 @@
 
 ## Goals
 
+In this lesson we will learn how to create, configure, and schedule _checks_, and how to select which hosts to run them on, using subscriptions.
+You will learn more detail about how the backend and agents communicate, and how to integrate existing monitoring plugins.
+This lesson is intended for operators of Sensu, and assumes you have [set up a local workshop environment][setup_workshop].
+
 ## What are Checks?
 
 In Sensu, *checks* are monitoring jobs that are managed by the Sensu control plane, and executed by Sensu Agents.
@@ -432,3 +436,5 @@ Proxy entities are discussed in greater detail in [Lesson 13: Introduction to Pr
 [Share your feedback on Lesson 08](https://github.com/sensu/sensu-go-workshop/issues/new?template=lesson_feedback.md&labels=feedback%2Clesson-08&title=Lesson%2008%20Feedback)
 
 [Lesson 9: Introduction to Check Hooks](../09/README.md#readme)
+
+[setup_workshop]: ../02/README.md#readme


### PR DESCRIPTION
Closes #69 and #70. 

This PR re-orgs Lessons 7/8 in the workshop. However, this is incomplete. 

Notably in Lesson 8, there's some TODOs that need to be addressed before merge, and there's some content about Entities in Lesson 7 that should be moved into a new lesson (or to an appendix if we don't want to renumber lessons/flow by adding a new lesson). Need to discuss plan there.

