### PR TITLE
fix: backend url in config

### DIFF
--- a/lessons/operator/07/README.md
+++ b/lessons/operator/07/README.md
@@ -244,7 +244,7 @@ Stop the agent, modify the configuration, then restart the agent.
 
    ```yaml
    ---
-   backend_url: ws://127.0.0.1:8080
+   backend-url: ws://127.0.0.1:8080
    name: workshop
    labels:
      foo: bar


### PR DESCRIPTION
Wrong `backend_url` should be `backend-url`
https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/agent/